### PR TITLE
Update setup.py, added huggingface-hub version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ requirements = [
     "transformers",
     "datasets",
     "vllm",
+    "huggingface-hub==0.23.5"
 ]
 
 setup(


### PR DESCRIPTION
Update setup.py, added huggingface-hub version==0.23.5.
This is to tackle the error, 

"llama-index-llms-huggingface 0.2.5 requires huggingface-hub<0.24.0,>=0.23.0, but you have huggingface-hub 0.24.6 which is incompatible." when command "pip install -e ."